### PR TITLE
Sort favorites chronologically on Schedule page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ $RECYCLE.BIN/
 *.ide
 
 **/wwwroot/js/app
+
+!/testdata/*.csv

--- a/readme.md
+++ b/readme.md
@@ -12,3 +12,15 @@ The project uses the following technologies:
 * Vue 2
 * TypeScript
 * Azure Blog Storage
+
+## Running locally
+
+You must have [SQL Server Express LocalDB](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/sql-server-express-localdb?view=sql-server-2017) installed and started.
+
+1. clone the repo
+1. run `npm install` from the `src/CoreCodeCamp` folder
+1. edit `src/CoreCodeCamp/appsettings.json`
+  - set `SeedDatabase` to `true`
+  - set `IterateDatabase` to `true`
+1. run the app with VS Code or Visual Studio or `dotnet run`
+1. restore the settings above back to `false` to avoid re-creating the database from scratch each time

--- a/src/CoreCodeCamp/Data/CodeCampRepository.cs
+++ b/src/CoreCodeCamp/Data/CodeCampRepository.cs
@@ -291,6 +291,7 @@ namespace CoreCodeCamp.Data
                     Talks = g.ToList()
                   };
 
+      // split the slots into before/after lunch
       var results = new List<IEnumerable<ScheduleModel>>()
       {
         slots.Where(a => a.Time.TimeOfDay < TimeSpan.FromHours(12)).ToList(),

--- a/src/CoreCodeCamp/Data/CodeCampRepository.cs
+++ b/src/CoreCodeCamp/Data/CodeCampRepository.cs
@@ -240,6 +240,7 @@ namespace CoreCodeCamp.Data
       return user.FavoriteTalks
         .Where(t => t.Talk.Speaker.Event.Moniker == moniker)
         .Select(t => t.Talk)
+        .OrderBy(t => t.TimeSlot.Time)
         .ToList();
     }
 

--- a/src/CoreCodeCamp/Data/CodeCampSeeder.cs
+++ b/src/CoreCodeCamp/Data/CodeCampSeeder.cs
@@ -43,7 +43,7 @@ namespace CoreCodeCamp.Data
       {
         if (_env.IsDevelopment())
         {
-          if (_config["Data:IterateDatabase"].ToLower() == "true")
+          if (_config.GetValue<bool>("Data:IterateDatabase"))
           {
             await _ctx.Database.EnsureDeletedAsync();
             await _ctx.Database.EnsureCreatedAsync();

--- a/src/CoreCodeCamp/Data/CodeCampSeeder.cs
+++ b/src/CoreCodeCamp/Data/CodeCampSeeder.cs
@@ -234,11 +234,9 @@ namespace CoreCodeCamp.Data
             };
             _ctx.Add(sponsor);
 
-
-
-            _ctx.AddRange(Add2015Sponsors(codeCamps.Where(s => s.Moniker == "2015").First()));
-            _ctx.AddRange(Add2014Sponsors(codeCamps.Where(s => s.Moniker == "2014").First()));
-            _ctx.AddRange(Add2013Sponsors(codeCamps.Where(s => s.Moniker == "2013").First()));
+            _ctx.AddRange(Add2015Sponsors(codeCamps.First(s => s.Moniker == "2015")));
+            _ctx.AddRange(Add2014Sponsors(codeCamps.First(s => s.Moniker == "2014")));
+            _ctx.AddRange(Add2013Sponsors(codeCamps.First(s => s.Moniker == "2013")));
 
             await _ctx.SaveChangesAsync();
           }
@@ -697,8 +695,7 @@ namespace CoreCodeCamp.Data
 
     private async Task Migrate()
     {
-
-      var speakerFile = Path.Combine(_env.ContentRootPath, @"..\..\speakers.csv");
+      var speakerFile = Path.Combine(_env.ContentRootPath, @"..\..\testdata\speakers.csv");
       if (File.Exists(speakerFile))
       {
         using (var oldSpeakers = new CsvReader(File.OpenText(speakerFile)))
@@ -742,7 +739,7 @@ namespace CoreCodeCamp.Data
     {
       var result = new List<Talk>();
 
-      var talkFile = Path.Combine(_env.ContentRootPath, @"..\..\talks.csv");
+      var talkFile = Path.Combine(_env.ContentRootPath, @"..\..\testdata\talks.csv");
       if (File.Exists(talkFile))
       {
         using (var oldTalks = new CsvReader(File.OpenText(talkFile)))

--- a/src/CoreCodeCamp/Program.cs
+++ b/src/CoreCodeCamp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,11 +21,15 @@ namespace CoreCodeCamp
         .UseStartup<Startup>()
         .Build();
 
-      IConfiguration config = host.Services.GetService<IConfiguration>();
-      var shouldSeed = config.GetValue<bool>("Data:SeedDatabase");
-      if (shouldSeed)
+      var env = host.Services.GetService<IHostingEnvironment>();
+      if (env.IsDevelopment())
       {
-        Seed(host).Wait();
+        IConfiguration config = host.Services.GetService<IConfiguration>();
+        var shouldSeed = config.GetValue<bool>("Data:SeedDatabase");
+        if ( shouldSeed)
+        {
+          Seed(host).Wait();
+        }
       }
 
       host.Run();

--- a/src/CoreCodeCamp/Program.cs
+++ b/src/CoreCodeCamp/Program.cs
@@ -20,14 +20,18 @@ namespace CoreCodeCamp
         .UseStartup<Startup>()
         .Build();
 
-      //Seed(host).Wait();
+      IConfiguration config = host.Services.GetService<IConfiguration>();
+      var shouldSeed = config.GetValue<bool>("Data:SeedDatabase");
+      if (shouldSeed)
+      {
+        Seed(host).Wait();
+      }
 
       host.Run();
     }
 
     private static async Task Seed(IWebHost host)
     {
-      IConfiguration config = host.Services.GetService<IConfiguration>();
       IServiceScopeFactory scopeFactory = host.Services.GetService<IServiceScopeFactory>();
       using (var scope = scopeFactory.CreateScope())
       {

--- a/src/CoreCodeCamp/appsettings.json
+++ b/src/CoreCodeCamp/appsettings.json
@@ -4,7 +4,8 @@
   },
   "Data": {
     "DbCodeCamp": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=AtlantaCodeCamp;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=True;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-    "IterateDatabase": false
+    "IterateDatabase": false,
+    "SeedDatabase": false
   },
   "Admin": {
     "SuperUser": {

--- a/testdata/speakers.csv
+++ b/testdata/speakers.csv
@@ -1,0 +1,2 @@
+Year,Bio,Blog,CompanyName,CompanyUrl,ImageUrl,Name,Title,Twitter,Id
+2017,empty bio,http://blog.example.com,Test Company,http://company.example.com,http://image.example.com,Speaker Name,Speaker Title,@example,123

--- a/testdata/talks.csv
+++ b/testdata/talks.csv
@@ -1,0 +1,4 @@
+Speaker_Id,Abstract,Audience,CodeUrl,Level,Prerequisites,PresentationUrl,SpeakerDeckUrl,SpeakerRateUrl,Title,Category,Room,StartTime
+123,Example abstract,Example audience,http://code.example.com,123,Prerequisites,http://presentation.example.com,http://deck.example.com,http://rate.example.com,Talk Title 1,Category,Example Room,11:00am
+123,Example abstract,Example audience,http://code.example.com,123,Prerequisites,http://presentation.example.com,http://deck.example.com,http://rate.example.com,Talk Title 2,Category,Example Room,2:00pm
+123,Example abstract,Example audience,http://code.example.com,123,Prerequisites,http://presentation.example.com,http://deck.example.com,http://rate.example.com,Talk Title 3,Category,Example Room,4:00pm


### PR DESCRIPTION
Displays the favorites listed on the Schedule page in chronological order; resolves #34 

The only runtime-relevant change is in `CodeCampRepository.GetUserWithFavoriteTalksForEvent`.

In order to test this locally, I had to figure out how to create/seed the database and made that a configuration option instead of [un]commenting the `Seed` call in `Program.cs`. Seeding is only enabled in a `Development` environment.

Had to re-create CSV files to import speaker/talk data and also allow them to be committed in the `.gitignore`.